### PR TITLE
chore: add github link in demo site

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,10 @@
 </script>
 
 <Toaster />
+<header>
 <h1>svelte-input</h1>
+<a href="https://github.com/jill64/svelte-input">GitHub</a>
+</header>
 <main>
   <FileInput>
     <div
@@ -69,9 +72,22 @@
       color: white;
     }
   }
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 0.5rem;
+  }
   main {
     display: inline-flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 1rem;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,8 +15,8 @@
 
 <Toaster />
 <header>
-<h1>svelte-input</h1>
-<a href="https://github.com/jill64/svelte-input">GitHub</a>
+  <h1>svelte-input</h1>
+  <a href="https://github.com/jill64/svelte-input">GitHub</a>
 </header>
 <main>
   <FileInput>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a new header section on the "svelte-input" page. This includes a title and a direct link to the GitHub repository, providing users with easy access to the source code.
- Style: Enhanced the visual appeal of the header section with modern styling and alignment for a cleaner look. Also, added a hover effect to the link for better user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->